### PR TITLE
[Fix] Place 응답 DTO에 위도, 경도, 주소 추가

### DIFF
--- a/src/main/java/COTATO_Combine_Networking/Networking/NetworkingApplication.java
+++ b/src/main/java/COTATO_Combine_Networking/Networking/NetworkingApplication.java
@@ -7,7 +7,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @OpenAPIDefinition(
 		servers = {
+				//@Server(url = "http://localhost:8080", description = "Local Server"),
 				@Server(url = "http://3.133.128.168:8080", description = "Production Server"),
+
 		}
 )
 @SpringBootApplication

--- a/src/main/java/COTATO_Combine_Networking/Networking/domain/place/converter/PlaceConverter.java
+++ b/src/main/java/COTATO_Combine_Networking/Networking/domain/place/converter/PlaceConverter.java
@@ -8,6 +8,8 @@ public class PlaceConverter {
     public static Place toEntity(PlaceCreateRequest request) {
         return Place.builder()
                 .placeName(request.getPlaceName())
+                .addressName(request.getPlaceName())
+                .roadAddressName(request.getRoadAddressName())
                 .latitude(request.getLatitude())
                 .longitude(request.getLongitude())
                 .build();
@@ -17,6 +19,9 @@ public class PlaceConverter {
         return PlaceResponse.builder()
                 .placeId(place.getId())
                 .placeName(place.getPlaceName())
+                .placeAddress(place.getAddressName())
+                .longitude(place.getLongitude())
+                .latitude(place.getLatitude())
                 .build();
     }
 }

--- a/src/main/java/COTATO_Combine_Networking/Networking/domain/place/dto/response/PlaceResponse.java
+++ b/src/main/java/COTATO_Combine_Networking/Networking/domain/place/dto/response/PlaceResponse.java
@@ -13,4 +13,6 @@ public class PlaceResponse {
     private Long placeId;
     private String placeName;
     private String placeAddress;
+    private String longitude;
+    private String latitude;
 }

--- a/src/main/java/COTATO_Combine_Networking/Networking/domain/place/service/PlaceService.java
+++ b/src/main/java/COTATO_Combine_Networking/Networking/domain/place/service/PlaceService.java
@@ -44,7 +44,7 @@ public class PlaceService {
 
     public List<PlaceResponse> findAll() {
         return placeRepository.findAll().stream()
-                .map(place -> new PlaceResponse(place.getId(), place.getPlaceName(), place.getAddressName()))
+                .map(place -> new PlaceResponse(place.getId(), place.getPlaceName(), place.getAddressName(), place.getLongitude(), place.getLatitude()))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## Description
- `PlaceResponse` DTO에 `latitude`, `longitude`, `address` 필드 추가
- 장소 저장/조회 시 위도, 경도, 주소 정보가 응답에 포함되도록 `PlaceConverter.toResponse` 메서드 수정


### Screenshots
<img width="813" alt="image" src="https://github.com/user-attachments/assets/5703714b-b2ff-4207-a3f3-4c5416592f8c" />
