### PR TITLE
[Fix] 시간대(KST) 반영하여 오전/오후 분류 오류 수정

### DIFF
--- a/src/main/java/COTATO_Combine_Networking/Networking/domain/weather/dto/response/WeatherForecastResponse.java
+++ b/src/main/java/COTATO_Combine_Networking/Networking/domain/weather/dto/response/WeatherForecastResponse.java
@@ -5,6 +5,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -25,9 +28,11 @@ public class WeatherForecastResponse {
 
         public int getHour() {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-            LocalDateTime dt = LocalDateTime.parse(this.dt_txt, formatter);
-            return dt.getHour();
+            LocalDateTime utcDateTime = LocalDateTime.parse(this.dt_txt, formatter);
+            ZonedDateTime seoulTime = utcDateTime.atZone(ZoneOffset.UTC).withZoneSameInstant(ZoneId.of("Asia/Seoul"));
+            return seoulTime.getHour();
         }
+
     }
 
     @Data


### PR DESCRIPTION
## Description
- OpenWeatherMap API에서 제공하는 `dt_txt`는 기본적으로 UTC 시간인데 기존 코드에서는 이를 Asia/Seoul(KST)로 변환하지 않고 `getHour()`를 사용해 부정확하게 표시되는 문제 발생
- `dt_txt`를 LocalDateTime으로 파싱한 뒤, UTC로 간주하고 `ZonedDateTime`을 통해 KST로 변환


### Screenshots
<img width="776" alt="image" src="https://github.com/user-attachments/assets/f3f40caa-7df3-4b18-8be5-a49bb95a43e3" />
