### PR TITLE
[Feat] 대기 오염 조회 api 추가

### DIFF
--- a/src/main/java/COTATO_Combine_Networking/Networking/domain/weather/controller/WeatherController.java
+++ b/src/main/java/COTATO_Combine_Networking/Networking/domain/weather/controller/WeatherController.java
@@ -1,5 +1,6 @@
 package COTATO_Combine_Networking.Networking.domain.weather.controller;
 
+import COTATO_Combine_Networking.Networking.domain.weather.dto.response.AirPollutionResponse;
 import COTATO_Combine_Networking.Networking.domain.weather.dto.response.DailyWeatherSummary;
 import COTATO_Combine_Networking.Networking.domain.weather.service.WeatherService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,4 +38,15 @@ public class WeatherController {
     ) {
         return weatherService.getFiveDayForecast(lat, lon);
     }
+
+    @GetMapping("/air")
+    @CrossOrigin(origins = "*")
+    @Operation(summary = "대기 오염 정보 조회", description = "OpenWeather의 대기 오염 API를 통해 미세먼지 등 대기 질 정보를 조회합니다.")
+    public AirPollutionResponse getAirPollution(
+            @RequestParam double lat,
+            @RequestParam double lon
+    ) {
+        return weatherService.getAirPollution(lat, lon);
+    }
+
 }

--- a/src/main/java/COTATO_Combine_Networking/Networking/domain/weather/dto/response/AirPollutionResponse.java
+++ b/src/main/java/COTATO_Combine_Networking/Networking/domain/weather/dto/response/AirPollutionResponse.java
@@ -1,0 +1,78 @@
+package COTATO_Combine_Networking.Networking.domain.weather.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AirPollutionResponse {
+
+    @Schema(description = "위치 좌표 정보")
+    private Coord coord;
+    private List<AirData> list;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Coord {
+        private double lon;
+        private double lat;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AirData {
+        @Schema(description = "대기질 지수 정보")
+        private Main main;
+
+        @Schema(description = "대기 오염 성분 농도 정보")
+        private Components components;
+
+        @Schema(description = "데이터 측정 시간 (Unix timestamp)", example = "1747879386")
+        private long dt;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Main {
+        @Schema(description = "대기질 지수 (AQI) 값, 1: 좋음(Good), 2: 보통(Fair), 3: 보통(Moderate), 4: 나쁨(Poor), 5: 매우 나쁨(Very Poor)", example = "1")
+        private int aqi;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "대기 오염 성분 농도 (μg/m³)")
+    public static class Components {
+
+        @Schema(description = "일산화탄소 농도", example = "99.94")
+        private double co;
+
+        @Schema(description = "일산화질소 농도", example = "0.03")
+        private double no;
+
+        @Schema(description = "이산화질소 농도", example = "0.11")
+        private double no2;
+
+        @Schema(description = "오존 농도", example = "38.61")
+        private double o3;
+
+        @Schema(description = "아황산가스 농도", example = "0.16")
+        private double so2;
+
+        @Schema(description = "미세먼지 PM2.5 농도", example = "1.72")
+        private double pm2_5;
+
+        @Schema(description = "미세먼지 PM10 농도", example = "7.33")
+        private double pm10;
+
+        @Schema(description = "암모니아 농도", example = "0")
+        private double nh3;
+    }
+}
+

--- a/src/main/java/COTATO_Combine_Networking/Networking/domain/weather/service/WeatherService.java
+++ b/src/main/java/COTATO_Combine_Networking/Networking/domain/weather/service/WeatherService.java
@@ -1,9 +1,6 @@
 package COTATO_Combine_Networking.Networking.domain.weather.service;
 
-import COTATO_Combine_Networking.Networking.domain.weather.dto.response.DailyWeatherSummary;
-import COTATO_Combine_Networking.Networking.domain.weather.dto.response.HalfDayWeather;
-import COTATO_Combine_Networking.Networking.domain.weather.dto.response.WeatherCurrentResponse;
-import COTATO_Combine_Networking.Networking.domain.weather.dto.response.WeatherForecastResponse;
+import COTATO_Combine_Networking.Networking.domain.weather.dto.response.*;
 import COTATO_Combine_Networking.Networking.global.apiPayload.code.status.ErrorStatus;
 import COTATO_Combine_Networking.Networking.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +29,9 @@ public class WeatherService {
 
     @Value("${weather.current-url}")
     private String currentUrl;
+
+    @Value("${weather.air-url}")
+    private String airUrl;
 
 
     private String buildUrl(String baseUrl, double lat, double lon) {
@@ -141,6 +141,22 @@ public class WeatherService {
                 .mapToDouble(i -> i.getPop() * 100) // % 변환
                 .average()
                 .orElse(0);
+    }
+
+    // 대기 오염 조회
+    public AirPollutionResponse getAirPollution(double lat, double lon) {
+        String url = airUrl +
+                "?lat=" + lat +
+                "&lon=" + lon +
+                "&appid=" + apiKey;
+
+        AirPollutionResponse response = restTemplate.getForObject(url, AirPollutionResponse.class);
+
+        if (response == null) {
+            throw new GeneralException(ErrorStatus.API_RESPONSE_EMPTY);
+        }
+
+        return response;
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,4 @@ weather:
   api-key: d364b0258b887a52cfd560c72aef20ac
   forecast-url: https://api.openweathermap.org/data/2.5/forecast
   current-url: https://api.openweathermap.org/data/2.5/weather
+  air-url: https://api.openweathermap.org/data/2.5/air_pollution


### PR DESCRIPTION
## Description
- OpenWeather API를 활용한 대기오염 정보 조회 기능 구현
- 위도(latitude), 경도(longitude) 기반 실시간 대기질 지수 및 주요 오염물질 농도 정보 제공

### Screenshots
<img width="809" alt="image" src="https://github.com/user-attachments/assets/4251bd38-bf07-40e1-b489-2e47ae9edffd" />
