### PR TITLE
[Fix] 서울 기준 날짜 및 시간 처리 로직 수정

### DIFF
--- a/src/main/java/COTATO_Combine_Networking/Networking/domain/weather/dto/response/WeatherForecastResponse.java
+++ b/src/main/java/COTATO_Combine_Networking/Networking/domain/weather/dto/response/WeatherForecastResponse.java
@@ -4,10 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -25,6 +22,13 @@ public class WeatherForecastResponse {
         private List<Weather> weather;
         private double pop; // 0.0 ~ 1.0
         private String dt_txt;
+
+        public LocalDate getKstDate() {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+            LocalDateTime utcDateTime = LocalDateTime.parse(this.dt_txt, formatter);
+            ZonedDateTime seoulDateTime = utcDateTime.atZone(ZoneOffset.UTC).withZoneSameInstant(ZoneId.of("Asia/Seoul"));
+            return seoulDateTime.toLocalDate();
+        }
 
         public int getHour() {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");

--- a/src/main/java/COTATO_Combine_Networking/Networking/domain/weather/service/WeatherService.java
+++ b/src/main/java/COTATO_Combine_Networking/Networking/domain/weather/service/WeatherService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -50,24 +51,23 @@ public class WeatherService {
             throw new GeneralException(ErrorStatus.API_RESPONSE_EMPTY);
         }
 
-        // 날짜별로 그룹화(ex-"2025-05-20")
-        Map<String, List<WeatherForecastResponse.WeatherItem>> grouped = forecastResponse.getList().stream()
-                .collect(Collectors.groupingBy(item -> item.getDt_txt().substring(0, 10)));
+        // 서울 기준 오늘 날짜
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
-        LocalDate today = LocalDate.now();
+        // 날짜별로 그룹화 (서울 기준 날짜로)
+        Map<LocalDate, List<WeatherForecastResponse.WeatherItem>> grouped = forecastResponse.getList().stream()
+                .collect(Collectors.groupingBy(WeatherForecastResponse.WeatherItem::getKstDate));
 
         // 오늘부터 이후 5일만 필터링
-        List<String> targetDates = grouped.keySet().stream()
-                .map(LocalDate::parse)
+        List<LocalDate> targetDates = grouped.keySet().stream()
                 .filter(date -> !date.isBefore(today))
                 .sorted()
                 .limit(5)
-                .map(LocalDate::toString)
                 .toList();
 
         List<DailyWeatherSummary> summaries = new ArrayList<>();
 
-        for (String date : targetDates) {
+        for (LocalDate date : targetDates) {
             List<WeatherForecastResponse.WeatherItem> items = grouped.get(date);
 
             List<WeatherForecastResponse.WeatherItem> am = items.stream()
@@ -101,7 +101,7 @@ public class WeatherService {
             }
 
             summaries.add(new DailyWeatherSummary(
-                    date,
+                    date.toString(),
                     amWeather,
                     summarizeHalfDay(pm)
             ));
@@ -120,6 +120,7 @@ public class WeatherService {
                 averagePop(items)
         );
     }
+
 
     private String mostFrequentWeather(List<WeatherForecastResponse.WeatherItem> items) {
         return items.stream()


### PR DESCRIPTION
## Description
- 주간 예보 api에 오늘 오후가 비어있는 오류가 발생해 KST 기준으로 날씨 예보 그룹화 및 오전/오후 분리해 오류 수정

### Screenshots
<img width="732" alt="image" src="https://github.com/user-attachments/assets/2f84fce6-22f9-44d7-bd90-bdb95312e271" />
